### PR TITLE
Fixed incorrectly connected Storyboards in Example project

### DIFF
--- a/Examples/RxCoreMotionExample/Base.lproj/Main.storyboard
+++ b/Examples/RxCoreMotionExample/Base.lproj/Main.storyboard
@@ -208,7 +208,7 @@
         <!--Magnetometer-->
         <scene sceneID="Apl-x8-xyb">
             <objects>
-                <viewController id="0uO-BE-k6H" customClass="GyroscopeViewController" customModule="RxCoreMotionExample" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="0uO-BE-k6H" customClass="MagnetometerViewController" customModule="RxCoreMotionExample" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="3jX-Vw-mYR"/>
                         <viewControllerLayoutGuide type="bottom" id="njR-8C-VFr"/>
@@ -241,7 +241,7 @@
         <!--Device Motion-->
         <scene sceneID="820-kE-0eG">
             <objects>
-                <viewController id="c1q-u1-T2x" customClass="GyroscopeViewController" customModule="RxCoreMotionExample" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="c1q-u1-T2x" customClass="DeviceMotionViewController" customModule="RxCoreMotionExample" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="O9V-EM-kHV"/>
                         <viewControllerLayoutGuide type="bottom" id="dgT-b5-AB8"/>

--- a/Examples/RxCoreMotionExample/ViewControllers/DeviceMotionViewController.swift
+++ b/Examples/RxCoreMotionExample/ViewControllers/DeviceMotionViewController.swift
@@ -27,7 +27,7 @@ class DeviceMotionViewController: UIViewController {
 
         coreMotionManager
             .flatMapLatest { manager in
-                manager.acceleration ?? Observable.empty()
+                manager.deviceMotion ?? Observable.empty()
             }
             .observeOn(MainScheduler.instance)
             .subscribe(onNext: { deviceMotion in


### PR DESCRIPTION
This fixes a few issues in the example project which prevented testing device motion and magnetometer updates, by referencing wrong classes and methods.